### PR TITLE
Update encode.js to add saving functionality

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -701,7 +701,7 @@ startButton.onclick = () => {
 	}
 
 	sstvFormat.getDuration = function() {
-		return (this.numScanLines * (this.scanLineLength + this.blankingInterval) + this.syncPulseLength) + 1;
+		return (this.numScanLines * (this.scanLineLength + this.blankingInterval + this.syncPulseLength * 3);
 	};
 
 	let oscillator = audioCtx.createOscillator();


### PR DESCRIPTION
I changed the pull request so it is linked to my fork: ignore the previous one.

Added functionality to allow users to save encoded SSTV audio as a WAV file using the MediaRecorder API.

On page load, the download button is disabled.
The MediaRecorder API records the output of the encoded waveforms and converts the audio buffer into a WAV file.
The download button only becomes clickable when the image is done encoding, and then when clicked, the audio will be downloaded to the user's computer as `sstv_{image_filename}.wav`.
