### PR TITLE
Update Scottie 1 VIS code in encode.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Summary
 Web SSTV aims to both encode and decode SSTV using plain JavaScript and Web Audio API. Web SSTV can be run entirely offline (without styling), and on any platform from Chromebooks to phones, so long as they support JavaScript and Web Audio. By making SSTV readily available on many platforms, we aim to create educational opportunities and introduce more people to STEM and amateur radio. Web SSTV is currently hosted at https://ckegel.github.io/Web-SSTV/.
 ## Current State
-Currently Web SSTV supports encoding images using the Martin, Scottie, PD, and WRASSE SC2-180 formats. Support for transmitting in the Robot format and in black and white underway. Decoding has proven to be a greater challenge. I am currently in the process of writing a custom Web Audio Worklet that leverages the Goertzel Algorithm to detect VIS headers and sync pulses. Pull requests are welcome.
+Currently Web SSTV supports encoding images using the Martin, Scottie, PD, and WRAASE SC2-180 formats. Support for transmitting in the Robot format and in black and white underway. Decoding has proven to be a greater challenge. I am currently in the process of writing a custom Web Audio Worklet that leverages the Goertzel Algorithm to detect VIS headers and sync pulses. Pull requests are welcome.
 ## Sources
 Both the [SSTV Handbook](https://www.sstv-handbook.com/) and [JL Barber's (N7CXI) Proposal for SSTV Mode Specifications ](http://www.barberdsp.com/downloads/Dayton%20Paper.pdf) were heavily referenced when implementing support for the Martin and Scottie formats.
 ## License

--- a/encode.html
+++ b/encode.html
@@ -29,8 +29,8 @@
 			<option value="S1">Scottie 1</option>
 			<option value="S2">Scottie 2</option>
 			<option value="SDX">Scottie DX</option>
-			<option value="none" disabled>--- WRASSE ---</option>
-			<option value="WrasseSC2180">SC2-180</option>
+			<option value="none" disabled>--- WRAASE ---</option>
+			<option value="WraaseSC2180">SC2-180</option>
 			<option value="none" disabled>--- PD ---</option>
 			<option value="PD50">PD-50</option>
 			<option value="PD90">PD-90</option>

--- a/encode.js
+++ b/encode.js
@@ -294,7 +294,7 @@ class ScottieOne extends ScottieBase {
 		let blankingInterval = 0.0015;
 		let scanLineLength = 0.138240;
 		let syncPulseLength = 0.009;
-		let VISCode = [false, true, true, true, true, false, false];
+		let VISCode = [false, false, true, true, true, true, false];
 
 		super(numScanLines, vertResolution, blankingInterval, scanLineLength, syncPulseLength, VISCode);
 	}

--- a/encode.js
+++ b/encode.js
@@ -464,7 +464,7 @@ class PD290 extends PDBase {
 	}
 }
 
-class WrasseSC2 extends Format {
+class WraaseSC2 extends Format {
 	prepareImage(data) {
 		let preparedImage = [];
 		for(let scanLine = 0; scanLine < this.numScanLines; ++scanLine){
@@ -507,7 +507,7 @@ class WrasseSC2 extends Format {
 		return (super.numScanLines * (super.syncPulseLength + super.blankingInterval + super.scanLineLength * 3));
 	}
 }
-class WrasseSC2180 extends WrasseSC2 {
+class WraaseSC2180 extends WraaseSC2 {
 	constructor() {
 		let numScanLines = 256;
 		let vertResolution = 320;
@@ -614,8 +614,8 @@ modeSelect.addEventListener("change", (e) => {
 		sstvFormat = new PD290();
 	else if(modeSelect.value == "RobotBW8")
 		sstvFormat = new RobotBW8();
-	else if(modeSelect.value == "WrasseSC2180")
-		sstvFormat = new WrasseSC2180();
+	else if(modeSelect.value == "WraaseSC2180")
+		sstvFormat = new WraaseSC2180();
 
 	if(imageLoaded)
 		drawPreview();


### PR DESCRIPTION
When reading least significant bit first, the VIS code for Scottie 1 used to read 30 '0011110'. Now it correctly reads 60 '0111100'.

To verify this, I experienced issues with other SSTV decoding programs which read the VIS code as 30. The fact that the VIS code is least significant bit first comes from this paper: http://www.barberdsp.com/downloads/Dayton%20Paper.pdf